### PR TITLE
feat(detector): Implement typing detector

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,7 @@ Metrics/LineLength:
   Max: 100
   Exclude:
     - "fusuma-plugin-*.gemspec"
+    - "**/*_spec.rb"
+
+Metrics/MethodLength:
+  Max: 15

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ plugin:
 
 ## Properties
 
+### Keypress
 Add `keypress:` property in `~/.config/fusuma/config.yml`.
 
 Keys following are available for `keypress`.
@@ -79,6 +80,29 @@ plugin:
 * Swipe up/down with four fingers while keypress LEFTMETA key to change display brightnes .
 * Swipe up/down with four fingers while keypress LEFTMETA and LEFTALT keys to change audio volume.
   - If you want to combine a gesture with two keys, combine modifier keys with `+`
+
+
+## Typing Gesture
+
+`typing:` is a trigger that fires when keys other than modifier keys are pressed. This trigger provides disable-while-typing similar to libinput and syndaemon.
+If you are using a keyremapper such as xkeysnail and libinput's disable-while-typing does not work, try setting it.
+
+It can be placed in the root of yaml and configured as a gesture.
+The following is a configuration that uses xinput to turn off tapping for 0.6 seconds to avoid false touches.
+
+```yaml
+typing: # disable while typing
+  command: |
+    touchpad_id=$(xinput | grep Touchpad | grep -oE "id=[0-9]*" | cut -d"=" -f 2)
+    xinput set-prop $touchpad_id "libinput Tapping Enabled" 0
+    file=/tmp/typing_command_break
+    touch "$file"
+    sleep 0.6
+    [ `find "$file" -mmin +0.01` ] && \
+      xinput set-prop $touchpad_id "libinput Tapping Enabled" 1
+  interval: 0.5
+```
+
 
 ## Contributing
 

--- a/fusuma-plugin-keypress.gemspec
+++ b/fusuma-plugin-keypress.gemspec
@@ -25,4 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.1' # https://packages.ubuntu.com/search?keywords=ruby&searchon=names&exact=1&suite=all&section=main
   # support bionic (18.04LTS) 2.5.1
   spec.add_dependency 'fusuma', '~> 2.0'
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 end

--- a/lib/fusuma/plugin/events/records/keypress_record.rb
+++ b/lib/fusuma/plugin/events/records/keypress_record.rb
@@ -12,6 +12,7 @@ module Fusuma
           def initialize(status:, code:)
             @status = status
             @code = code
+            super()
           end
         end
       end

--- a/lib/fusuma/plugin/filters/keypress_filter.rb
+++ b/lib/fusuma/plugin/filters/keypress_filter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fusuma/device'
+
 module Fusuma
   module Plugin
     module Filters
@@ -7,10 +9,54 @@ module Fusuma
       class KeypressFilter < Filter
         DEFAULT_SOURCE = 'libinput_command_input'
 
+        def config_param_types
+          {
+            source: String,
+            keep_device_names: [Array, String]
+          }
+        end
+
+        # NOTE: example of line# Select keyboard devices for filtering devices pressed/released
+        # event4   KEYBOARD_KEY      +4.81s      KEY_LEFTSHIFT (42) pressed
+        # event4   KEYBOARD_KEY      +4.90s      KEY_LEFTSHIFT (42) released
+        # event4   KEYBOARD_KEY      +7.39s      KEY_CAPSLOCK (58) pressed
+        # event4   KEYBOARD_KEY      +7.52s      KEY_CAPSLOCK (58) released
+        # event4   KEYBOARD_KEY      +8.98s      KEY_LEFTCTRL (29) pressed
+        # event4   KEYBOARD_KEY      +9.14s      KEY_LEFTCTRL (29) released
+
         # @return [TrueClass] when keeping it
         # @return [FalseClass] when discarding it
         def keep?(record)
-          record.to_s =~ /\sKEYBOARD_KEY\s/
+          keep_devices.any? do |d|
+            record.to_s =~ /#{d.id}\s+KEYBOARD_KEY\s/
+          end
+        end
+
+        private
+
+        # @return [Array<Fusuma::Device>]
+        def keep_devices
+          @keep_devices ||= KeepDevice.new(config_params(:keep_device_names)).select
+        end
+
+        # Devices to detect key presses and releases
+        class KeepDevice
+          def initialize(names)
+            @names = names
+          end
+
+          # @return [Array<Fusuma::Device>]
+          def select
+            if @names
+              Fusuma::Device.all.select do |d|
+                Array(config_params(:keep_device_names)).any? do |name|
+                  d.name =~ name
+                end
+              end
+            else
+              Fusuma::Device.all.select { |d| d.capabilities =~ /keyboard/ }
+            end
+          end
         end
       end
     end

--- a/lib/fusuma/plugin/parsers/keypress_parser.rb
+++ b/lib/fusuma/plugin/parsers/keypress_parser.rb
@@ -7,18 +7,6 @@ module Fusuma
       class KeypressParser < Parser
         DEFAULT_SOURCE = 'libinput_command_input'
 
-        AVAILABLE_KEYS = %w[
-          CAPSLOCK
-          LEFTALT
-          LEFTCTRL
-          LEFTMETA
-          LEFTSHIFT
-          RIGHTALT
-          RIGHTCTRL
-          RIGHTSHIFT
-          RIGHTMETA
-        ].freeze
-
         # @param record [String]
         # @return [Records::Gesture, nil]
         def parse_record(record)
@@ -38,8 +26,6 @@ module Fusuma
             # time = matched[1]   # 4.81
             code = matched[2]   # LEFTSHIFT
             status = matched[3] # pressed
-
-            return unless AVAILABLE_KEYS.include?(code)
 
             Events::Records::KeypressRecord.new(status: status, code: code)
           end

--- a/spec/fusuma/plugin/filters/keypress_filter_spec.rb
+++ b/spec/fusuma/plugin/filters/keypress_filter_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'fusuma/plugin/filters/filter'
+require 'fusuma/plugin/inputs/input'
+
+require './lib/fusuma/plugin/filters/keypress_filter'
+
+module Fusuma
+  module Plugin
+    module Filters
+      RSpec.describe KeypressFilter do
+        describe '#keep?' do
+          before { @filter = KeypressFilter.new }
+          context 'with keyboard event' do
+            before do
+              keyboard = double(Fusuma::Device, id: 'event4')
+              allow(@filter).to receive(:keep_devices).and_return([keyboard])
+              text = " #{keyboard.id}   KEYBOARD_KEY      +4.81s      KEY_LEFTSHIFT (42) pressed"
+              @event = Events::Event.new(tag: 'libinput_command_input', record: text)
+              # @filter = KeypressFilter.new
+            end
+            it 'should be true' do
+              expect(@filter.keep?(@event.record)).to eq true
+            end
+          end
+          context 'with multiple keyboards' do
+            before do
+              keyboard1 = double(Fusuma::Device, id: 'event1')
+              keyboard2 = double(Fusuma::Device, id: 'event2')
+              allow(@filter).to receive(:keep_devices).and_return([
+                                                                    keyboard1, keyboard2
+                                                                  ])
+              text1 = " #{keyboard1.id}   KEYBOARD_KEY      +4.81s      KEY_LEFTSHIFT (42) pressed"
+              text2 = " #{keyboard2.id}   KEYBOARD_KEY      +4.81s      KEY_LEFTSHIFT (42) pressed"
+              @event1 = Events::Event.new(tag: 'libinput_command_input', record: text1)
+              @event2 = Events::Event.new(tag: 'libinput_command_input', record: text2)
+            end
+            it 'should return multiple keyboards' do
+              expect(@filter.keep?(@event1.record)).to eq true
+              expect(@filter.keep?(@event2.record)).to eq true
+            end
+          end
+          context 'when touchpad events' do
+            before do
+              touchpad = double(Fusuma::Device, id: 'event18')
+              allow(@filter).to receive(:keep_devices).and_return([touchpad])
+              text = " #{touchpad.id}  GESTURE_SWIPE_UPDATE  +1.44s  4 11.23/ 1.00 (36.91/ 3.28 unaccelerated) "
+              #                        ^^^^^^^^^^^^^^^^^^^^  Shoud be KEYBOARD_KEY
+              @event = Events::Event.new(tag: 'libinput_command_input', record: text)
+            end
+            it 'should be false' do
+              expect(@filter.keep?(@event.record)).to eq false
+            end
+          end
+
+          context 'with plugins.filters.keypress_filter.source=CUSTOM_INPUT' do
+            it { expect(@filter.source).to eq 'libinput_command_input' }
+
+            context 'with config' do
+              around do |example|
+                @custom_source = 'CUSTOM_INPUT'
+
+                ConfigHelper.load_config_yml = <<~CONFIG
+                  plugin:
+                   filters:
+                     keypress_filter:
+                       source: #{@custom_source}
+                CONFIG
+
+                example.run
+
+                Config.custom_path = nil
+              end
+
+              it { expect(@filter.source).to eq @custom_source }
+            end
+          end
+          context "with config file having plugins.filters.keypress.keep_device_names='CUSTOM_KEYBOARD'" do
+            it { expect(@filter.source).to eq 'libinput_command_input' }
+
+            context 'with config' do
+              around do |example|
+                @name = 'CUSTOM_KEYBOARD'
+
+                ConfigHelper.load_config_yml = <<~CONFIG
+                  plugin:
+                   filters:
+                     keypress_filter:
+                       keep_device_names: #{@name}
+                CONFIG
+
+                example.run
+
+                Config.custom_path = nil
+              end
+
+              it { expect(@filter.config_params[:keep_device_names]).to eq @name }
+            end
+          end
+          context "with config file having plugins.filters.keypress.keep_device_names=['INTERNAL_KEYBOARD','EXTERNAL_KEYBOARD']" do
+            it { expect(@filter.source).to eq 'libinput_command_input' }
+
+            context 'with config' do
+              around do |example|
+                @name1 = 'INTERNAL_KEYBOARD'
+                @name2 = 'EXTERNAL_KEYBOARD'
+
+                ConfigHelper.load_config_yml = <<~CONFIG
+                  plugin:
+                   filters:
+                     keypress_filter:
+                       keep_device_names:
+                        - #{@name1}
+                        - #{@name2}
+                CONFIG
+
+                example.run
+
+                Config.custom_path = nil
+              end
+
+              it { expect(@filter.config_params(:keep_device_names)).to eq [@name1, @name2] }
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes: #6 

Typing detector detects typing without modifier keys.
Using `typing: {command: something}` is set on the root of config.yml. We can use this for triggering the script for disabling touch while typing.

Following config is a part of my ~/.config/fusuma/config.yml
```yaml
typing: # disable while typing
  command: |
    touchpad_id=$(xinput | grep Touchpad | grep -oE "id=[0-9]*" | cut -d"=" -f 2)
    xinput set-prop $touchpad_id "libinput Tapping Enabled" 0
    file=/tmp/typing_command_break
    touch "$file"
    sleep 0.6
    [ `find "$file" -mmin +0.01` ] && \
      xinput set-prop $touchpad_id "libinput Tapping Enabled" 1
  interval: 0.5
```