### PR TITLE
Remove typing trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,29 +81,6 @@ plugin:
 * Swipe up/down with four fingers while keypress LEFTMETA and LEFTALT keys to change audio volume.
   - If you want to combine a gesture with two keys, combine modifier keys with `+`
 
-
-## Typing trigger
-
-`typing:` is a trigger that fires when keys other than modifier keys are pressed. This trigger provides disable-while-typing similar to libinput and syndaemon.
-If you are using a keyremapper such as xkeysnail and libinput's disable-while-typing does not work, try setting it.
-
-It can be placed in the root of yaml and configured as a gesture.
-The following is a configuration that uses xinput to turn off tapping for 0.6 seconds to avoid false touches.
-
-```yaml
-typing: # disable while typing
-  command: |
-    touchpad_id=$(xinput | grep Touchpad | grep -oE "id=[0-9]*" | cut -d"=" -f 2)
-    xinput set-prop $touchpad_id "libinput Tapping Enabled" 0
-    file=/tmp/typing_command_break
-    touch "$file"
-    sleep 0.6
-    [ `find "$file" -mmin +0.01` ] && \
-      xinput set-prop $touchpad_id "libinput Tapping Enabled" 1
-  interval: 0.5
-```
-
-
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/iberianpig/fusuma-plugin-keypress. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/fusuma/plugin/detectors/keypress_detector.rb
+++ b/lib/fusuma/plugin/detectors/keypress_detector.rb
@@ -37,14 +37,12 @@ module Fusuma
 
           codes = pressed_codes(keypress_buffer.events.map(&:record))
 
-          return if codes.empty?
+          return unless codes.any? { |code| MODIFIER_KEYS.include?(code) }
 
-          record = if codes.any? { |code| MODIFIER_KEYS.include?(code) }
-            Events::Records::IndexRecord.new(index: create_index(codes: codes),
-              position: :surfix)
-          else
-            Events::Records::IndexRecord.new(index: create_typing_index)
-          end
+          record = Events::Records::IndexRecord.new(
+            index: create_index(codes: codes),
+            position: :surfix
+          )
 
           create_event(record: record)
         end
@@ -74,16 +72,6 @@ module Fusuma
             [
               Config::Index::Key.new("keypress", skippable: true),
               Config::Index::Key.new(codes.join("+"), skippable: true)
-            ]
-          )
-        end
-
-        # @param status [String]
-        # @return [Config::Index]
-        def create_typing_index
-          Config::Index.new(
-            [
-              Config::Index::Key.new("typing")
             ]
           )
         end


### PR DESCRIPTION
This feature was essentially a workaround for the disable-while-typing feature not functioning properly in libinput,
rather than a keypress function. As a result, this code can be removed.

The use of a typing trigger for a simulated disable-while-typing is no longer necessary.

In the case of external keyboards with libinput,
the disable-while-typing feature does not work.
Key remappers are often treated as external keyboards,
which can cause accidental taps.

Following code uses libinput quirks to treat xremap's virtual keyboard as an internal keyboard.

/etc/libinput/local-overrides.quirks
```
[xremap for disable-touch-while-typing]
MatchUdevType=keyboard
MatchName=xremap*
AttrKeyboardIntegration=internal
```
