### PR TITLE
Add Layer Information to Key Press Events

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ task :bump, :type do |_, args|
     gemspec = Gem::Specification.load(gemspec_path)
     config.user = gemspec.authors.first
     config.project = gemspec.name
-    config.future_release = next_version
+    config.future_release = "v#{next_version}"
   end
 
   Rake::Task[:changelog].execute

--- a/lib/fusuma/plugin/events/records/keypress_record.rb
+++ b/lib/fusuma/plugin/events/records/keypress_record.rb
@@ -6,13 +6,14 @@ module Fusuma
       module Records
         # Record for Keypress event
         class KeypressRecord < Record
-          attr_reader :status, :code
+          attr_reader :status, :code, :layer
 
           # @example
-          #  KeypressRecord.new(status: 'pressed', code: 'LEFTSHIFT')
+          #  KeypressRecord.new(status: 'pressed', code: 'LEFTSHIFT', layer: 'thumbsense')
           #
-          # @param status [String]
+          # @param status [String] 'pressed' or 'released'
           # @param code [String]
+          # @param layer [Hash] this field will be used from other plugin.
           def initialize(status:, code:, layer: nil)
             super()
             @status = status
@@ -21,7 +22,7 @@ module Fusuma
           end
 
           def to_s
-            "#{status} #{code}"
+            "#{status} #{code} #{layer}"
           end
         end
       end


### PR DESCRIPTION
- The keypress plugin communicates key presses, but it's important to know the context (layer) in which the key was pressed.
- Adding layer information serves as auxiliary data for continuing the context.
- Proposing to add a 'layer' field to the record field of keypress.
- This change is initially planned to be used in the Thumbsense plugin.
